### PR TITLE
fix repos url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ extra:
 
 # Repository
 repo_name: PegaSysEng/EthSigner
-repo_url: https://github.com/PegaSysEng/ethsigner
+repo_url: https://github.com/PegaSysEng/doc.ethsigner
 
 theme:
   name: material


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.ethsigner/blob/master/CONTRIBUTING.md -->

## PR description
URL used by the header link was still pointing to the previous repos...

