### PR TITLE
fix edit button link to work with separate doc and code repos

### DIFF
--- a/docs/custom_theme/main.html
+++ b/docs/custom_theme/main.html
@@ -34,3 +34,45 @@
   <script>const latestWarningTrigger = "{{config.extra.latest_version_warning.url_contains}}";</script>
   <div class="latest-warning">{{config.extra.latest_version_warning.text}}</div>
 {% endblock %}
+
+<!-- Content -->
+{% block content %}
+
+  <!-- Edit button, if URL was defined -->
+  <!--The button has to point to the doc site and as it's not designed to have doc outside of code
+  repos we have to replace the mkdocs generated link based on the code repos with the doc repos-->
+  {% if page.edit_url %}
+  <a href="{{ page.edit_url | replace(config.repo_url, config.extra.doc_site_edit_url) }}"
+     title="{{ lang.t('edit.link.title') }}"
+     class="md-icon md-content__icon">&#xE3C9;<!-- edit --></a>
+  {% endif %}
+
+  <!--
+    Hack: check whether the content contains a h1 headline. If it
+    doesn't, the page title (or respectively site name) is used
+    as the main headline.
+  -->
+  {% if not "\x3ch1" in page.content %}
+    <h1>{{ page.title | default(config.site_name, true)}}</h1>
+  {% endif %}
+
+  <!-- Content -->
+  {{ page.content }}
+
+  <!-- Source files -->
+  {% block source %}
+    {% if page and page.meta and page.meta.source %}
+      <h2 id="__source">{{ lang.t("meta.source") }}</h2>
+      {% set repo = config.repo_url %}
+      {% if repo | last == "/" %}
+        {% set repo = repo[:-1] %}
+      {% endif %}
+      {% set path = page.meta.path | default([""]) %}
+      {% set file = page.meta.source %}
+        <a href="{{ [repo, path, file] | join('/') }}"
+           title="{{ file }}" class="md-source-file">
+          {{ file }}
+        </a>
+    {% endif %}
+  {% endblock %}
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ copyright: EthSigner and its documentation are licensed under Apache 2.0 license
 
 #extra project info and template customisation
 extra:
+  doc_site_edit_url: https://github.com/PegaSysEng/doc.ethsigner/
   versions:
     stable: '0.1.1'
   latest_version_warning:
@@ -39,7 +40,7 @@ extra:
     tokenizer: '[\s]+'
 
 
-# Repository
+# Software Repository
 repo_name: PegaSysEng/EthSigner
 repo_url: https://github.com/PegaSysEng/ethsigner
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.ethsigner/blob/master/CONTRIBUTING.md -->

## PR description
fix edit button link to work with separate doc and code repos as the button has to point to the doc site and as it's not designed to have doc outside of code repos we have to replace the mkdocs generated link based on the code repos with the doc repos

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes ES-<Jira issue number> -->
<!-- Example: "fixes ES-1234" -->
none, it's site init.