### PR TITLE
fix community link and related link checker exclude regex

### DIFF
--- a/MKDOCS-MARKDOWN-GUIDE.md
+++ b/MKDOCS-MARKDOWN-GUIDE.md
@@ -8,7 +8,7 @@ However, we use two flavors of this syntax:
 in the [Installed Markdown Extensions](#installed-markdown-extensions) section.
 - Another using the [Github syntax](https://guides.github.com/features/mastering-markdown/) 
 for pages outside of this documentation directory. These are mainly files to support our [open source 
-community](https://github.com/PegaSysEng/ethsigner/community).
+community](https://github.com/PegaSysEng/doc.ethsigner/community).
 
 ## MkDocs Documentation Website
 

--- a/link_check_conf.json
+++ b/link_check_conf.json
@@ -7,7 +7,7 @@
             "pattern": "^http(s)?://127.0.0.1"
         },
         {
-            "pattern": "^http(s)?://github.com/PegaSysEng/ethsigner/community"
+            "pattern": "^http(s)?://github.com/PegaSysEng/doc.ethsigner/community"
         },
         {
             "pattern": "^http(s)?://ropsten.etherscan.io/txs\\?block="


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.ethsigner/blob/master/CONTRIBUTING.md -->

## Pull Request Description
Fix community link in contribution guide and also matching link checker regex.
The link was pointing to ethsigner community page instead of doc.ethsigner page.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes ES-<Jira issue number> -->
<!-- Example: "fixes ES-1234" -->
no ticket, just a small fix