### PR TITLE
add linkchecker node script to package.json scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,17 +59,13 @@ jobs:
           keys:
             - deps-{{ checksum "package.json" }}
       - run:
-          # copy files into this volume
           name: Install dependencies
           command: |
             npm install
       - run:
-          # copy files into this volume
           name: Run markdown link checker
           command: |
-            find . -name \*.md ! -path "./node_modules/*" -exec ./node_modules/markdown-link-check/markdown-link-check -q -c link_check_conf.json {} \; > linkchecker.out 2>&1
-            cat ./linkchecker.out
-            ! grep "ERROR:" ./linkchecker.out
+            npm run test:links
       - save_cache:
           paths:
             - ./node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ site/
 env/
 *.out
 node_modules/
+.circleci/process.yml

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test:links:check": "find . -name \\*.md ! -path \"./node_modules/*\" -exec ./node_modules/markdown-link-check/markdown-link-check -q -c link_check_conf.json {} \\; > linkchecker.out 2>&1",
+    "test:links:display": "cat ./linkchecker.out",
+    "test:links:verify": "! grep 'ERROR:' ./linkchecker.out",
+    "test:links": "npm run test:links:check && npm run test:links:display && npm run test:links:verify",
+    "test": "npm run test:links"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.ethsigner/blob/master/CONTRIBUTING.md -->

## Pull Request Description
add linkchecker node script to package.json scripts instead of ci script

fixes pantheon part of pan-3117

will enable more consistent experience when sample test scripts will be added to
package.json too.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes ES-<Jira issue number> -->
<!-- Example: "fixes ES-1234" -->
fixes ethsigner part of [pan-3117](https://pegasys1.atlassian.net/browse/PAN-3117)