### PR TITLE
EthSigner does not support mulit-tenancy

### DIFF
--- a/docs/HowTo/Use-Multiple-Signers.md
+++ b/docs/HowTo/Use-Multiple-Signers.md
@@ -4,29 +4,37 @@ description: Use Multiple Signers
 
 # Use multiple signing keys
 
-Each account that signs transactions requires a key. EthSigner supports
-[multiple keys](../Tutorials/Multifile.md) stored in:
+EthSigner supports transaction signing using [multiple stored keys](../Tutorials/Multifile.md).
+Any account submitting transactions to EthSigner can use the stored keys. The keys can be stored
+in:
 
 * A [V3 keystore file](../Tutorials/Multifile.md##create-password-and-key-files)
   stored on a file system accessible by the host.
-* [Hashicorp Vault](../HowTo/Store-Keys/Use-Hashicorp.md).
-* [Azure Key Vault](../HowTo/Store-Keys/Use-Azure.md).
+* A [Hashicorp Vault](../HowTo/Store-Keys/Use-Hashicorp.md).
+* An [Azure Key Vault](../HowTo/Store-Keys/Use-Azure.md).
 
-Each key requires a separate [TOML file](../Reference/Multikey-Parameters.md) that defines
-the parameters to access the key. The TOML files must be placed in a single
-directory specified using the [`multikey-signer --directory`](../Reference/CLI/CLI-Syntax.md#multikey-options) subcommand.
+!!! caution
 
-!!! tip
-    Files can be added or removed from the directory without needing to
-    restart EthSigner.
+    The ability to use mulitiple signing keys should be limited to the accounts with access to the
+    stored keys.
 
-The TOML file name must use the format `[<prefix>]<accountAddress>.toml`. The
-prefix can be anything you want. No two TOML files can have the same key address
-in the file name, even if the prefix differs.
-
-The `0x` portion of the account address must be removed.
-For example, `78e6e236592597c09d5c137c2af40aecd42d12a2.toml`
+Each key requires a separate [TOML file](../Reference/Multikey-Parameters.md) that defines the
+parameters to access the key. The TOML files must be placed in a single directory specified using
+the [`multikey-signer --directory`](../Reference/CLI/CLI-Syntax.md#multikey-options) subcommand.
 
 !!! tip
-    Use the [`export-address`](https://besu.hyperledger.org/en/latest/Reference/CLI/CLI-Subcommands/#export-address)
+
+    Files can be added or removed from the directory without needing to restart EthSigner.
+
+The TOML file name must use the format `[<prefix>]<accountAddress>.toml`. The prefix can be
+anything you want. No two TOML files can have the same key address in the file name, even if the
+prefix differs.
+
+Remove the `0x` portion of the account address. For example,
+`78e6e236592597c09d5c137c2af40aecd42d12a2.toml`.
+
+!!! tip
+
+    Use the
+    [`export-address`](https://besu.hyperledger.org/en/latest/Reference/CLI/CLI-Subcommands/#export-address)
     Hyperledger Besu subcommand to obtain the account address of the node.

--- a/docs/Tutorials/Multifile.md
+++ b/docs/Tutorials/Multifile.md
@@ -129,7 +129,7 @@ account address. For example, `78e6e236592597c09d5c137c2af40aecd42d12a2.toml`.
 Start EthSigner with options:
 
 * `chain-id` is the chain ID specified in the
-[Besu genesis file](https://besu.hyperledger.org/en/stable/Reference/Config-Items/).
+  [Besu genesis file](https://besu.hyperledger.org/en/stable/Reference/Config-Items/).
 * `downstream-http-port` is the `rpc-http-port` specified for Besu (`8590` in this example).
 * `directory` is the location of TOML file [created above](#create-the-toml-file).
 

--- a/docs/Tutorials/Multifile.md
+++ b/docs/Tutorials/Multifile.md
@@ -6,17 +6,27 @@ description: Signing transactions with multiple keys.
 
 EthSigner supports transaction signing using [multiple keys](../HowTo/Use-Multiple-Signers.md).
 
-This tutorial covers configuring multiple keys using V3 keystore files. To
-configure keys for [Hashicorp Vault](../HowTo/Store-Keys/Use-Hashicorp.md)
-or [Azure Key Vault](../HowTo/Store-Keys/Use-Azure.md), update the
+This tutorial covers configuring multiple keys using V3 keystore files. To configure keys for
+[Hashicorp Vault](../HowTo/Store-Keys/Use-Hashicorp.md) or
+[Azure Key Vault](../HowTo/Store-Keys/Use-Azure.md), update the
 [TOML configuration file](../Reference/Multikey-Parameters.md) accordingly.
+
+!!! note
+
+    Multiple signing keys is not the same as multi-tenancy. EthSigner does not support
+    multi-tenancy.
+
+    Multi-tenancy is a feature in
+    [Hyperledger Besu](https://besu.hyperledger.org/en/stable/Concepts/Privacy/Multi-Tenancy/) and
+    [Orion](https://docs.orion.pegasys.tech/en/stable/Concepts/Multi-Tenancy/) allowing multiple
+    participants in a privacy network to use the same Besu and Orion node.
 
 ## Prerequisites
 
 * [EthSigner](../HowTo/Get-Started/Install-Binaries.md)
 * [Hyperledger Besu](https://besu.hyperledger.org/en/stable/HowTo/Get-Started/Install-Binaries/)
 * [Node.js](https://nodejs.org/en/download/)
-* [web3.js](https://github.com/ethereum/web3.js/)
+* [web3.js](https://github.com/ethereum/web3.js/).
 
 ## Start Besu
 
@@ -32,17 +42,16 @@ option set to `8590`.
 
 ## Create password and key files
 
-You can create one or more password and V3 Keystore key files. Create a text
-file containing the password for the V3 Keystore key file to be created
-(for example, `passwordFile`).
+You can create one or more password and V3 Keystore key files. Create a text file containing the
+password for the V3 Keystore key file to be created (for example, `passwordFile`).
 
-!!! attention "Password text file must not contain characters other than those used in your password"
-    EthSigner reads the password file as binary and any character in the file is
-    considered part of your password.
+!!! attention "Password text file must not contain characters other than those in your password."
 
-    _Some POSIX compliant editors automatically add an end-of-line in text files.
-    If your editor adds an end-of-line character, the end-of-line is considered
-    part of your password._
+    EthSigner reads the password file as binary and any character in the file is considered part of
+    your password.
+
+    Some POSIX compliant editors automatically add an end-of-line character in text files, which
+    will be considered part of your password.
 
     Use the following command to ensure the password file is correct:
 
@@ -54,11 +63,9 @@ file containing the password for the V3 Keystore key file to be created
 
 Use the [web3.js library](https://github.com/ethereum/web3.js/) to create a key file where:
 
-* `<AccountPrivateKey>` is the private key of the account with which EthSigner
-   will sign transactions.
-* `<Password>` is the password for the key file being created. The password must
-   match the password saved in the  password file created previously
-   (`passwordFile` in this example).
+* `<AccountPrivateKey>` is the account private key EthSigner uses to sign transactions.
+* `<Password>` is the key file password being created. The password must match the password saved
+  in the  password file created previously (`passwordFile` in this example).
 
 !!! example
 
@@ -84,8 +91,8 @@ Use the [web3.js library](https://github.com/ethereum/web3.js/) to create a key 
     process.exit();
     ```
 
-Copy and paste the example JS script to a file (for example, `createKeyFile.js`)
-and replace the placeholders.
+Copy and paste the example JS script to a file (for example, `createKeyFile.js`) and replace the
+placeholders.
 
 Use the JS script to display the text for the key file:
 
@@ -93,17 +100,16 @@ Use the JS script to display the text for the key file:
 node createKeyFile.js
 ```
 
-Copy and paste the text to a file (for example, `keyFile`). The file is your
-V3 Keystore key file. Each key file requires a TOML file.
+Copy and paste the text to a file (for example, `keyFile`). The file is your V3 Keystore key file.
+Each key file requires a TOML file.
 
-## Create the TOML File
+## Create the TOML file
 
-Create the TOML file that contains the settings to access the key file.
-Each key that signs transactions requires a TOML file.
+Create the TOML file that contains the settings to access the key file. Each key that signs
+transactions requires a TOML file.
 
-The file name must use the format `[<prefix>]<accountAddress>.toml`. The `0x`
-portion of the account address must be removed.
-For example, `78e6e236592597c09d5c137c2af40aecd42d12a2.toml`.
+The file name must use the format `[<prefix>]<accountAddress>.toml`. Remove the `0x` portion of the
+account address. For example, `78e6e236592597c09d5c137c2af40aecd42d12a2.toml`.
 
 !!! example
 
@@ -122,11 +128,9 @@ For example, `78e6e236592597c09d5c137c2af40aecd42d12a2.toml`.
 
 Start EthSigner with options:
 
-* `chain-id` is the chain ID specified in the [Besu genesis file](https://besu.hyperledger.org/en/stable/Reference/Config-Items/).
-
-* `downstream-http-port` is the `rpc-http-port` specified for Besu
-  (`8590` in this example).
-
+* `chain-id` is the chain ID specified in the
+[Besu genesis file](https://besu.hyperledger.org/en/stable/Reference/Config-Items/).
+* `downstream-http-port` is the `rpc-http-port` specified for Besu (`8590` in this example).
 * `directory` is the location of TOML file [created above](#create-the-toml-file).
 
 !!! example
@@ -135,7 +139,7 @@ Start EthSigner with options:
     ethsigner --chain-id=2018 --downstream-http-port=8590 multikey-signer --directory=/Users/me/project
     ```
 
-## Confirm EthSigner is up
+## Confirm EthSigner is running
 
 Use the `upcheck` endpoint to confirm EthSigner is running.
 
@@ -149,9 +153,10 @@ Use the `upcheck` endpoint to confirm EthSigner is running.
     I'm up
     ```
 
-## Confirm EthSigner passing requests to Besu
+## Confirm EthSigner is passing requests to Besu
 
-Request the current block number using [`eth_blockNumber`](https://besu.hyperledger.org/en/stable/Reference/API-Methods/#eth_blocknumber)
+Request the current block number using
+[`eth_blockNumber`](https://besu.hyperledger.org/en/stable/Reference/API-Methods/#eth_blocknumber)
 with the EthSigner JSON-RPC endpoint (`8545` in this example):
 
 ```bash


### PR DESCRIPTION
Added a note that multiple signing keys is not the same as multi-tenancy, and multi-tenancy is not supported. Also included a brief description about multi-tenancy in Besu and Orion, with links. Also made markdown lint and vale updates (things like line length, fixing up bullet points, spacing, etc.)
Fixes #66 